### PR TITLE
Add jid suffix selector

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,0 @@
-Prosody shared roster from LDAP
-
-This is a toy shared roster written for Hackerspace Warsaw - it pulls all users from a prescribed group and automatically adds them to a user's roster.
-
-Very basic functionality, more updates hopefully coming soon.
-

--- a/README.markdown
+++ b/README.markdown
@@ -14,6 +14,7 @@ This modules accepts the following additionnal settings:
 * ldap_nameattr: Sets the attribute that sets the user name (displayed in the roster afterwards) (default: cn)
 * group_name: Sets the shared roster name (default: 'Shared roster')
 * refresh_time: Refresh the shared roster every X seconds (default: 60)
+* jid_hostname: Select which source will be used to fill the hostname part of the user JID (default: virtualhost, to use the current virtualhost, may be basedn to use the LDAP basedn or an arbitrary value)
 
 Example:
 ```lua
@@ -22,5 +23,6 @@ ldap_roster = {
 	ldap_nameattr = 'cn';
 	group_name    = 'Shared roster';
 	refresh_time  = 60;
+	jid_hostname  = 'virtualhost'
 };
 ```

--- a/README.markdown
+++ b/README.markdown
@@ -1,0 +1,26 @@
+# Prosody shared roster from LDAP
+
+This is a toy shared roster written for Hackerspace Warsaw.
+It pulls all users matching a specific filter using LDAP and automatically adds them to every user's roster.
+
+Very basic functionality, more updates hopefully coming soon.
+
+## Configuration
+
+LDAP settings are the same as the ones used by https://modules.prosody.im/mod_auth_ldap.html
+
+This modules accepts the following additionnal settings:
+* ldap_uidattr: Sets the attribute that sets the user part of the JID (default: uid)
+* ldap_nameattr: Sets the attribute that sets the user name (displayed in the roster afterwards) (default: cn)
+* group_name: Sets the shared roster name (default: 'Shared roster')
+* refresh_time: Refresh the shared roster every X seconds (default: 60)
+
+Example:
+```lua
+ldap_roster = {
+	ldap_uidattr  = 'uid';
+	ldap_nameattr = 'cn';
+	group_name    = 'Shared roster';
+	refresh_time  = 60;
+};
+```

--- a/mod_roster_ldap.lua
+++ b/mod_roster_ldap.lua
@@ -1,17 +1,24 @@
 local lualdap = require 'lualdap';
 local timer = require 'util.timer';
-local options = module:get_option('ldap_roster') or {}
-local ldap_server = options.ldap_server or 'ldap.hackerspace.pl'
-local ldap_tls = options.ldap_tls or true;
-local ldap_filter = options.ldap_filter or 'memberOf=cn=xmpp-users,ou=Group,dc=hackerspace,dc=pl';
-local ldap_base = options.ldap_base or 'ou=People,dc=hackerspace,dc=pl';
-local ldap_binddn = options.ldap_binddn or '';
-local ldap_bindpass = options.ldap_bindpass or '';
-local ldap_scope = options.ldap_scope or 'onelevel';
-local ldap_uidattr = options.ldap_uidattr or 'uid';
+
+-- Get LDAP parameters from mod_auth_ldap settings
+local ldap_server   = module:get_option_string("ldap_server", "localhost");
+local ldap_base     = assert(module:get_option_string("ldap_base"), "ldap_base is a required option for ldap");
+local ldap_tls      = module:get_option_boolean("ldap_tls");
+local ldap_filter   = module:get_option_string("ldap_filter", "(uid=*)");
+local ldap_binddn   = module:get_option_string("ldap_rootdn", "");
+local ldap_bindpass = module:get_option_string("ldap_password", "");
+local ldap_scope    = module:get_option_string("ldap_scope", "subtree");
+
+-- Get mod_roster_ldap ones from our own configuration container
+local options       = module:get_option('ldap_roster') or {}
+local ldap_uidattr  = options.ldap_uidattr or 'uid';
 local ldap_nameattr = options.ldap_nameattr or 'cn';
-local group_name = options.group_name or 'Hackerspace';
-local refresh_time = options.refresh_time or 60;
+local group_name    = options.group_name or 'Shared roster';
+local refresh_time  = options.refresh_time or 60;
+
+module:log('debug', 'Module enabled, searching for \''..ldap_filter..'\' in '..ldap_base..' ('..ldap_server..')')
+module:log('debug', 'Refreshing shared roster every '..refresh_time..' seconds')
 
 local lc = assert(lualdap.open_simple(ldap_server, ldap_binddn, ldap_bindpass, ldap_tls),
 	'Could not connect to LDAP server');

--- a/mod_roster_ldap.lua
+++ b/mod_roster_ldap.lua
@@ -16,6 +16,7 @@ local ldap_uidattr  = options.ldap_uidattr or 'uid';
 local ldap_nameattr = options.ldap_nameattr or 'cn';
 local group_name    = options.group_name or 'Shared roster';
 local refresh_time  = options.refresh_time or 60;
+local jid_hostname  = options.jid_hostname or 'virtualhost';
 
 module:log('debug', 'Module enabled, searching for \''..ldap_filter..'\' in '..ldap_base..' ('..ldap_server..')')
 module:log('debug', 'Refreshing shared roster every '..refresh_time..' seconds')
@@ -53,7 +54,12 @@ local function dc_to_host(dn)
 end
 
 local function ldap_to_entry(dn, attrs)
-	local host = dc_to_host(dn);
+	local host = jid_hostname;
+	if jid_hostname == 'virtualhost' then
+		host = module:get_host();
+	elseif jid_hostname == 'basedn' then
+		host = dc_to_host(dn)
+	end
 	local na = attrs[ldap_nameattr];
 	local name = type(na) == 'table' and na[1] or na;
 	return { jid = attrs[ldap_uidattr]..'@'..host, name=name };

--- a/mod_roster_ldap.lua
+++ b/mod_roster_ldap.lua
@@ -105,9 +105,9 @@ local function update_roster()
 		local entry = ldap_to_entry(dn, attrs);
 		ldap_roster[entry.jid] = entry
 	end
-	module:log('info', 'updated LDAP roster')
+	module:log('debug', 'LDAP roster has been refreshed')
 	--push_all_rosters()
-	--module:log('info', 'pushed updated rosters')
+	--module:log('info', 'LDAP roster has been pushed')
 	return refresh_time
 end
 


### PR DESCRIPTION
This PR requires #2 #3 and #4 to be merged first.

It enables the user to select how the hostname part of the shared users will be constructed: either using the current virtualhost, the LDAP basedn (previous default) or an arbitrary value.
